### PR TITLE
Added Option 'ignore_transport_errors' to silence any transport errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Possible configuration parameters are:
 * `append` Array of anonymous functions (actually anything that `is_callable()`). Their return strings get appended to the message body.
 * `additional`  Array of anonymous functions (actually anything that `is_callable()`). Their return values get added as additional fields to the GELF message.
 * `levels` Array of log level, that will be sent to Graylog. See `\Psr\Log\LogLevel` for all possible values. Default: all of them.
+* `ignore_transport_errors` Ignore transport errors Default: `false`
 
 ### Further reading
 

--- a/src/Log/Engine/GraylogLog.php
+++ b/src/Log/Engine/GraylogLog.php
@@ -15,6 +15,7 @@ use kbATeam\PhpBacktrace\ClassicBacktrace;
 use LogicException;
 use kbATeam\GraylogUtilities\LogTypes;
 use kbATeam\GraylogUtilities\Obfuscator;
+use Gelf\Transport\IgnoreErrorTransportWrapper;
 
 /**
  * Class GraylogLog
@@ -58,7 +59,8 @@ class GraylogLog extends BaseLog
             'old_password',
             'current_password'
         ],
-        'levels' => []
+        'levels' => [],
+        'ignore_transport_errors' => false
     ];
 
     /**
@@ -166,7 +168,15 @@ class GraylogLog extends BaseLog
     protected function getPublisher()
     {
         if ($this->publisher === null) {
-            $this->publisher = new Publisher($this->getTransport());
+
+            $transport = $this->getTransport();
+
+            if($this->getConfig('ignore_transport_errors') === true){               
+                $transport = new IgnoreErrorTransportWrapper($transport);
+            }
+            
+            $this->publisher = new Publisher($transport);
+            
         }
         return $this->publisher;
     }


### PR DESCRIPTION
Added option to make use of the `IgnoreErrorTransportWrapper` now introduced in gelf-php package. 

https://github.com/bzikarsky/gelf-php/issues/56

This will stop our applications crashing when our DNS fails / Graylog server is down.

Please let me know if theres anything else required.
